### PR TITLE
setup.py classifiers are explicit in Python versions supported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,4 +8,8 @@ setup(name='rfc3339',
       author_email='tonyg@lshift.net',
       url='http://www.lshift.net/',
       py_modules=['rfc3339'],
+      classifiers=[
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 3'
+      ],
       )


### PR DESCRIPTION
These classifiers are regarding which versions of python are supported, making support for Python 3 explicit.

It's these classifiers that helps [this tool](https://github.com/brettcannon/caniusepython3) (`caniusepython3`) understand this project won't be a blocker to Python 3 migration.

That tool was discovered via [this article](https://tech.yplanapp.com/2016/08/24/upgrading-to-python-3-with-zero-downtime/).