### PR TITLE
Add parse_time and timetostr

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 import os
 
 setup(name='rfc3339',
-      version='0.1',
+      version='0.2',
       description='Python implementation of RFC 3339',
       author='Tony Garnock-Jones',
       author_email='tonyg@lshift.net',


### PR DESCRIPTION
Hi @tonyg,

First of all thanks a lot for this library. I found it one of the most sane choices for rfc3339 parser available in Python. We are using this library for implementing date and time formats in our JSON Schema library and would like to contribute back a few patches.

This PR adds `parse_time` and `timetostr` functions that allow us to not only support `date-time` JSONSchema format but pure `time` as well. I essentially extracted time parsing code into a function and reused it in both `parse_time` and `parse_datetime`.

Added tests to both functions. Checked that doctests are passing on both python 2.7 and 3.6.